### PR TITLE
Fix: Allow blank newlines between members in object definitions.

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
     test_coral_code = """
 object Point
   x // Field
+
   y // Field
 
   fn move(dx, dy) // Method

--- a/parser.py
+++ b/parser.py
@@ -448,6 +448,12 @@ class Parser:
         self.consume(INDENT)
         members = []
         while self.current_token.type != DEDENT and self.current_token.type != EOF:
+            # Skip any blank lines
+            while self.current_token.type == NEWLINE:
+                self.advance()
+            # If after skipping newlines we are at DEDENT or EOF, break the loop
+            if self.current_token.type == DEDENT or self.current_token.type == EOF:
+                break
             members.append(self._parse_field_or_method_member()) # Use helper
         self.consume(DEDENT)
         return ObjectDefinitionNode(name=name_node, members=members, location_info=loc)


### PR DESCRIPTION
The parser's `parse_object_definition` method was modified to consume any NEWLINE tokens encountered while looking for object members. This allows for blank lines to be present between fields or methods within an object definition without causing a ParseError.

NOTE: I was unable to fully test this change with a modified test case in `main.py` due to a persistent and unrelated SyntaxError in `lexer.py`. The lexer issue (SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape at lexer.py line 396 involving '```') needs to be addressed separately. This commit includes only the targeted fix in `parser.py` for the newline handling.